### PR TITLE
Fix for broken "python setup.py install"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(	name='py2d',
 	author='Stefan Seemayer',
 	author_email='mail@semicolonsoftware.de',
 
-	packages=['py2d'],
+	packages=['py2d', 'py2d.vecmath'],
 )


### PR DESCRIPTION
The recent 'vecmath' package was not installed, this just adds it to setup.py's list of installed packages.
