### PR TITLE
'pip install' now works.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ MANIFEST
 *.py[co]
 *.c
 *.so
+/.eggs/
 
 # Packages
 *.egg

--- a/py2d/Bezier.py
+++ b/py2d/Bezier.py
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 """Bezier curve tools.
 
 All functions in this module assume the following naming:

--- a/py2d/FOV.py
+++ b/py2d/FOV.py
@@ -1,4 +1,7 @@
+# cython: language_level=3
+
 """Calculation of polygonal Field of View (FOV)"""
+
 import functools
 import py2d.Math
 

--- a/py2d/FOVConverter.py
+++ b/py2d/FOVConverter.py
@@ -1,4 +1,7 @@
+# cython: language_level=3
+
 """Conversion of map data structures to obstructor data"""
+
 import Math
 
 def convert_tilemap(width, height, blocking_function, tile_width, tile_height):

--- a/py2d/Math/Operations.py
+++ b/py2d/Math/Operations.py
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 import math
 
 from py2d.Math.Vector import *

--- a/py2d/Math/Polygon.py
+++ b/py2d/Math/Polygon.py
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 import math
 import itertools
 from collections import defaultdict

--- a/py2d/Math/Transform.py
+++ b/py2d/Math/Transform.py
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 import math
 
 from py2d.Math.Vector import *

--- a/py2d/Math/Vector.py
+++ b/py2d/Math/Vector.py
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 import math
 from collections import defaultdict
 

--- a/py2d/Math/__init__.py
+++ b/py2d/Math/__init__.py
@@ -1,4 +1,7 @@
+# cython: language_level=3
+
 """Math utilities for games"""
+
 from py2d.Math.Vector import *
 from py2d.Math.Polygon import *
 from py2d.Math.Transform import *

--- a/py2d/Navigation.py
+++ b/py2d/Navigation.py
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 """Navigation Mesh generation and navigation."""
 
 import itertools

--- a/py2d/SVG.py
+++ b/py2d/SVG.py
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 """SVG to Polygon conversion
 
 This is still experimental code and only a tiny subset of SVG is supported.

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
+from setuptools import setup, Extension
 
-from distutils.core import setup
-from distutils.extension import Extension
-from Cython.Distutils import build_ext
-
-setup(	name='py2d',
+setup(
+	name='py2d',
 	version='0.1',
 	description='Py2D library of 2D-game-related algorithms',
 	url='http://www.github.com/sseemayer/py2d',
@@ -12,7 +10,12 @@ setup(	name='py2d',
 	author_email='mail@semicolonsoftware.de',
 
 	packages=['py2d', 'py2d.Math'],
-	cmdclass = {'build_ext': build_ext},
+	setup_requires=[
+		# Setuptools 18.0 properly handles Cython extensions.
+		'setuptools>=18.0',
+		'wheel',
+		'cython',
+	],
 	ext_modules = [
 		Extension("py2d.Bezier", ["py2d/Bezier.py"]),
 		Extension("py2d.FOV", ["py2d/FOV.py"]),


### PR DESCRIPTION
Fixes issue: https://github.com/sseemayer/Py2D/issues/11

Modern versions of setuptools support a fix for this problem, as implemented in this PR.

Instead of importing build_ext from Cython, we can now use 'setup_requires' to declare our install-time requirements.

So pip installing now works, and once done, `python setup.py build_ext` works to build the Cython libraries.

## Also

* Not setting the Cython language_level directive nowadays produces warnings while building Cython libs. So I set language_level=3 (ie Python3 compatible) in each cythonized file.

  This is possibly a controversial choice. Advice welcome.

* Added the .eggs directory to .gitignore